### PR TITLE
 Fix: Kafka metadata fixes

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -31,7 +31,7 @@ type InputKafkaConfig struct {
 	Host       string `json:"input-kafka-host"`
 	Topic      string `json:"input-kafka-topic"`
 	UseJSON    bool   `json:"input-kafka-json-format"`
-	Offset     string  `json:"input-kafka-offset"`
+	Offset     string `json:"input-kafka-offset"`
 	SASLConfig SASLKafkaConfig
 }
 

--- a/output_kafka.go
+++ b/output_kafka.go
@@ -2,11 +2,12 @@ package goreplay
 
 import (
 	"encoding/json"
-	"github.com/buger/goreplay/internal/byteutils"
-	"github.com/buger/goreplay/proto"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/buger/goreplay/internal/byteutils"
+	"github.com/buger/goreplay/proto"
 
 	"github.com/Shopify/sarama"
 	"github.com/Shopify/sarama/mocks"
@@ -91,8 +92,9 @@ func (o *KafkaOutput) PluginWrite(msg *Message) (n int, err error) {
 	}
 
 	o.producer.Input() <- &sarama.ProducerMessage{
-		Topic: o.config.Topic,
-		Value: message,
+		Topic:     o.config.Topic,
+		Value:     message,
+		Timestamp: time.Now(),
 	}
 
 	return len(message), nil

--- a/output_kafka_test.go
+++ b/output_kafka_test.go
@@ -23,6 +23,12 @@ func TestOutputKafkaRAW(t *testing.T) {
 
 	resp := <-producer.Successes()
 
+	key, _ := resp.Key.Encode()
+
+	if string(key) != "2" {
+		t.Errorf("Key not properly encoded: %q", key)
+	}
+
 	data, _ := resp.Value.Encode()
 
 	if string(data) != "1 2 3\nGET / HTTP1.1\r\nHeader: 1\r\n\r\n" {
@@ -45,6 +51,12 @@ func TestOutputKafkaJSON(t *testing.T) {
 	output.PluginWrite(&Message{Meta: []byte("1 2 3\n"), Data: []byte("GET / HTTP1.1\r\nHeader: 1\r\n\r\n")})
 
 	resp := <-producer.Successes()
+
+	key, _ := resp.Key.Encode()
+
+	if string(key) != "2" {
+		t.Errorf("Key not properly encoded: %q", key)
+	}
 
 	data, _ := resp.Value.Encode()
 


### PR DESCRIPTION
This PR fixes the following issues:

1. Set Kafka's record timestamp as current timestamp
2. Set `ReqID` as Kafka's record key instead of empty string